### PR TITLE
pyxis: Don't set BTM_DEF_LOCAL_NAME

### DIFF
--- a/bluetooth/include/bdroid_buildcfg.h
+++ b/bluetooth/include/bdroid_buildcfg.h
@@ -21,14 +21,13 @@
 
 #ifndef _BDROID_BUILDCFG_H
 #define _BDROID_BUILDCFG_H
-
-#define BTM_DEF_LOCAL_NAME "Xiaomi Mi 9 Lite"
 // Disables read remote device feature
 #define MAX_ACL_CONNECTIONS   16
 #define MAX_L2CAP_CHANNELS    16
 #define BLE_VND_INCLUDED   TRUE
 // Skips conn update at conn completion
 #define BT_CLEAN_TURN_ON_DISABLED 1
+
 // Increasing SEPs to 12 from 6 to support SHO/MCast i.e. two streams per codec
 #define AVDT_NUM_SEPS 12
 #endif


### PR DESCRIPTION
pyxis is also MI CC 9 so it's better to don't set BTM_DEF_LOCAL_NAME as Mi 9 Lite